### PR TITLE
Template for opening issues.

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,30 @@
+<!--- Provide a general summary of the issue -->
+
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Steps to Reproduce
+<!--- Provide an unambiguous set of steps to reproduce this bug.
+      Include code to reproduce, if relevant. -->
+1.
+2.
+3.
+4.
+
+## Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+#### Service Fabric Runtime and SDK Version :
+
+#### Operating System :
+
+<!--- Cluster size and mention if dev box or prod/test box --->
+#### Cluster Size :
+
+## Possible Workaround
+<!--- Have you figured out any possible workaround of this issue --->

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,3 +1,6 @@
+<!--- If you only want to ask a query/question, feel free to remove the below template.
+      For bugs/issues, please fill as many fields as possible. --->
+
 <!--- Provide a general summary of the issue -->
 
 


### PR DESCRIPTION
Adds an issue template to ask obvious questions beforehand.
This will reduce initial to-and-fro time between OP and SF team.

Opening a new issue will look like this :

![service_fabric_issues](https://user-images.githubusercontent.com/1728946/33873564-7aafc6d2-df41-11e7-9a69-6e7a0ce64bbd.PNG)
